### PR TITLE
Limit File Type

### DIFF
--- a/src/FileInput.js
+++ b/src/FileInput.js
@@ -6,7 +6,7 @@ export default class FileInput extends Component {
     return (
       <div className="file-input-container">
         <h1>BFV</h1>
-        <input id="file-input" type="file" accepts=".csv" onChange={this.props.onChange} />
+        <input id="file-input" type="file" accept=".csv" onChange={this.props.onChange} />
         <label htmlFor="file-input">Choose a file</label>
       </div>
     );

--- a/src/FileInput.js
+++ b/src/FileInput.js
@@ -6,7 +6,7 @@ export default class FileInput extends Component {
     return (
       <div className="file-input-container">
         <h1>BFV</h1>
-        <input id="file-input" type="file" onChange={this.props.onChange} />
+        <input id="file-input" type="file" accepts=".csv" onChange={this.props.onChange} />
         <label htmlFor="file-input">Choose a file</label>
       </div>
     );


### PR DESCRIPTION
Added `accept=".csv"` to the `input .file-input` element to limit what files can be imported. Importing something that is not CSV to this will result in a blank page and this is an easy way to limit that.