### PR TITLE
Use redgifs API instead of gfycat

### DIFF
--- a/src/Show.js
+++ b/src/Show.js
@@ -23,7 +23,7 @@ const GfycatStore = (() => {
     get: async gfyId => {
       cleanExpired();
       if (!(gfyId in store)) {
-        const resp = await fetch(`https://api.gfycat.com/v1/gfycats/${gfyId}`);
+        const resp = await fetch(`https://api.redgifs.com/v1/gfycats/${gfyId}`);
         const json = await resp.json();
         store[gfyId] = {
           url: json.gfyItem.webmUrl,

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -80,8 +80,8 @@ export default class Viewer extends Component {
             value={list}
             onChange={e => this.setState({ list: e.target.value })}
           >
-            {Object.keys(links).map(l => (
-              <option value={l}>{l}</option>
+            {Object.keys(links).map((l, index) => (
+              <option key={index} value={l}>{l}</option>
             ))}
           </select>
           <button disabled={pos === links[list].length - 1} onClick={this.next}>


### PR DESCRIPTION
All NSFW content from Gfycat seems to have migrated to Redgifs, including the API. This PR will make sure the old Gfycat links still work, by using the drop-in replacement Redgifs API.

Also added `key=` to `<option>`s in `Viewer.js` to clear out a warning about keys not being used.